### PR TITLE
Fix static file loading

### DIFF
--- a/src/notespace/v2/live_reload.clj
+++ b/src/notespace/v2/live_reload.clj
@@ -29,7 +29,7 @@
               slurp)
       (note/render-ns nil)))
 
-;; Use to add current ns path prefix to URI so we cna load
+;; Use to add current ns path prefix to URI so we can load
 ;; static files directly from the ns output directory. This way
 ;; we can create a parallel experience between live loading
 ;; pages referencing static files (e.g. images) and the case

--- a/src/notespace/v2/live_reload.clj
+++ b/src/notespace/v2/live_reload.clj
@@ -41,7 +41,6 @@
                       (clojure.string/replace #"//" "/"))]
       (handler (assoc request :uri new-uri)))))
 
-
 (defn main [req]
   (->> (notespace-html)
        html-response))

--- a/src/notespace/v2/live_reload.clj
+++ b/src/notespace/v2/live_reload.clj
@@ -29,6 +29,11 @@
               slurp)
       (note/render-ns nil)))
 
+;; Use to add current ns path prefix to URI so we cna load
+;; static files directly from the ns output directory. This way
+;; we can create a parallel experience between live loading
+;; pages referencing static files (e.g. images) and the case
+;; where output files are loaded directly in the browser.
 (defn wrap-add-ns-path-prefix [handler]
   (fn [request]
     (let [curr-ns-path (note/ns->out-dir @note/last-ns-rendered)

--- a/src/notespace/v2/live_reload.clj
+++ b/src/notespace/v2/live_reload.clj
@@ -47,7 +47,7 @@
 
 (defroutes routes
   (GET "/" req (main req))
-  (wrap-inject-ns-path-prefix
+  (wrap-add-ns-path-prefix
    (route/files "" {:root (System/getProperty "user.dir")})))
 
 (def app (-> routes


### PR DESCRIPTION
## Problem

When live reloading in the context of the project, the server's routes had been set up with compojure to load static images from the `resources/static` path with a route `/static`. This setup conflicted with the intended scenario that some chart files would be sent to the output target of the current namespace (e.g. `/doc/someproject/some-ns`). 

In order to see files load locally, you had to output them to `/resources/static` and reference them in the namespace with the `/static/ path, which then meant that if you wanted to load those output files directly in the browser later, you'd have to change the path reference and the output target.

## Solution

One way to solve this is to set the root path for static files to be the project root, and then add a middleware that adds the path of the current namespace to the path specified in the URI that the user puts in the hiccup/html. So if the user puts in their note:
```clj
(note-hiccup [:img {:src "image.png"}])
```
Then the middleware will modify the URI to be `/doc/someproject/some-ns/image.png`. This is possible because notespace already has a way to access the output directory of the last ns that has been rendered, i.e. `(note/ns->out-dir @note/last-ns-rendered)`. The root path for the static files is set to be the absolute directory of the project root via `(System/getProperty "user.dir")`.

## Other Thoughts/Questions
Is there a better way to do this that is more flexible because this solution seems to be a bit brittle? It makes some pretty strong assumptions about how the user will use files, where they will want to output them, etc. And, worst of all, it adds the path to the URI in a way that is pretty well hidden from the user, and that they wouldn't expect. 

I suppose the one defense of this that I can come up with is that the output location for the file might be logically assumed to be the same as the location of the html that is produced. The only problem with that statement is that there is no such automatic behavior wrt to the clojisr's `plot->file` function, and there shouldn't be. 

The main thought I have is that this behavior might be something that we want to make more explicitly and could make more explicit in a configuration layer that is very visible to the user. I'm not yet very familiar with the configuration conventions for notespace, but I imagine this is possible. If this makes sense, I'm also not sure if it needs to be or even should be part of this PR.

