### PR TITLE
config: set docs to default target-base-path

### DIFF
--- a/src/notespace/defaults.clj
+++ b/src/notespace/defaults.clj
@@ -3,7 +3,7 @@
 
 (def initial-state
   {;; global configuration:
-   :config                {:target-base-path "doc"
+   :config                {:target-base-path "docs"
                            :single-note-mode? false
                            :render-src? true
                            :evaluation-callback-fn (fn [cur-node-idx node-count note])


### PR DESCRIPTION
GitHub pages can render content from the docs directory in a repository, so set
docs as the default location used when generating static html

Resolves #47 